### PR TITLE
Update README.md in "acherkogel"

### DIFF
--- a/README.md
+++ b/README.md
@@ -1,8 +1,9 @@
 # MountainOS LiteAir Default Settings
-Default settings for the MountainOS LiteAir desktop (themes, panel and menu layout, etc)
+Default settings for the MountainOS LiteAir "Acherkogel" desktop (themes, panel and menu layout, etc)
 
 This project is a dependency of mos-la-meta and installs our custom settings
 for Xfce and other apps. Packages provided include:
 
   * mos-la-default-settings
 
+This branch is no longer maintained, as MountainOS Lite no longer uses Xfce.


### PR DESCRIPTION
Noted that MountainOS LiteAir "acherkogel", based on Xfce, has been scrapped. All new changes are to "asgard" in preparation of MountainOS 1.0